### PR TITLE
Fix a typo affecting serialisation

### DIFF
--- a/asaplib/cluster/ml_cluster_fit.py
+++ b/asaplib/cluster/ml_cluster_fit.py
@@ -101,7 +101,7 @@ class sklearn_DB(FitClusterBase):
 
     def pack(self):
         """return all the info"""
-        return self.db.get_params
+        return self.db.get_params()
 
 
 class LAIO_DB(FitClusterBase):


### PR DESCRIPTION
Fix this typo which raises error during JSON serialisation in `clustering.py -algo  dbscan`.