### PR TITLE
Added support for CSV files

### DIFF
--- a/asaplib/cli/cmd_asap.py
+++ b/asaplib/cli/cmd_asap.py
@@ -491,7 +491,7 @@ def map(ctx, fxyz, design_matrix, prefix, output,
 
     # color scheme
     from asaplib.plot import set_color_function
-    plotcolor, plotcolor_peratom, colorlabel, colorscale = set_color_function(color, ctx.obj['asapxyz'], color_column, 0, peratom, use_atomic_descriptors, only_use_species, color_from_zero, normalized_by_size)
+    plotcolor, plotcolor_peratom, colorlabel, colorscale, external_data = set_color_function(color, ctx.obj['asapxyz'], color_column, 0, peratom, use_atomic_descriptors, only_use_species, color_from_zero, normalized_by_size)
     if color_label is not None: colorlabel = color_label
 
     ctx.obj['map_options'] =  { 'color': plotcolor,
@@ -501,7 +501,8 @@ def map(ctx, fxyz, design_matrix, prefix, output,
                              'peratom': peratom,
                              'annotate': [],
                              'outmode': output,
-                             'keepraw': keepraw
+                             'keepraw': keepraw,
+                             'external_data': external_data,
                            }
     if annotate != 'none':
         import numpy as np

--- a/asaplib/cli/cmd_cli_options.py
+++ b/asaplib/cli/cmd_cli_options.py
@@ -141,7 +141,7 @@ def color_setup_options(f):
                      default=None)(f)
     f = click.option('--color_column', '-ccol',
                      help='The column number used in the color file. Starts from 0.',
-                     default=0)(f)
+                     default='0')(f)
     f = click.option('--color', '-c',
                      help='Location of a file or name of the properties in the XYZ file. \
                      Used to color the scatter plot for all samples (N floats).',

--- a/asaplib/cli/func_asap.py
+++ b/asaplib/cli/func_asap.py
@@ -138,10 +138,11 @@ def map_process(obj, reduce_dict, axes, map_name):
     outfilename = obj['fig_options']['outfile']
     outmode = obj['map_options']['outmode']
     species_name = obj['map_options']['only_use_species']
+    external_data = obj['map_options']['external_data']
     if obj['map_options']['project_atomic']:
         map_save(outfilename, outmode, obj['asapxyz'], None, proj, map_name, species_name)
     else:
-        map_save(outfilename, outmode, obj['asapxyz'], proj, proj_atomic, map_name, species_name)
+        map_save(outfilename, outmode, obj['asapxyz'], proj, proj_atomic, map_name, species_name, external_data)
 
 def map_plot(fig_spec, proj, proj_atomic, plotcolor, plotcolor_atomic, labels, annotate, axes):
     """
@@ -155,7 +156,7 @@ def map_plot(fig_spec, proj, proj_atomic, plotcolor, plotcolor_atomic, labels, a
         asap_plot.plot(proj_atomic[::-1, axes], plotcolor_atomic[::-1],[],[])
     plt.show()
 
-def map_save(foutput, outmode, asapxyz, proj, proj_atomic, map_name, species_name):
+def map_save(foutput, outmode, asapxyz, proj, proj_atomic, map_name, species_name, external_data=None):
     """
     Save the low-D projections
     """
@@ -175,7 +176,11 @@ def map_save(foutput, outmode, asapxyz, proj, proj_atomic, map_name, species_nam
         else:
             # If we write atomic projection assume we want to show them
             cutoff = 3.5 if proj_atomic else None
-            asapxyz.write_chemiscope(foutput, cutoff=cutoff)
+            if external_data is not None:
+                extra = {str(colname): external_data[colname].values for colname in external_data.columns}
+            else:
+                extra = None
+            asapxyz.write_chemiscope(foutput, cutoff=cutoff, extra=extra)
     else:
         pass
 

--- a/asaplib/data/xyz.py
+++ b/asaplib/data/xyz.py
@@ -649,7 +649,7 @@ class ASAPXYZ:
         if save_acronym:
             self.save_descriptor_acronym_state(filename)
 
-    def write_chemiscope(self, filename, sbs=None, save_acronym=False, cutoff=None, wrap_output=True):
+    def write_chemiscope(self, filename, sbs=None, save_acronym=False, cutoff=None, wrap_output=True, extra=None):
         """
         write the selected frames or all the frames to ChemiScope JSON
 
@@ -658,6 +658,7 @@ class ASAPXYZ:
         filename: str
         sbs: array, integer
         cutoff: generate cutoff for atomic environments, set to None to disable atomic environments
+        extras: A dictionary of extra properties per structure to be written
         """
 
         from asaplib.io.cscope import write_chemiscope_input
@@ -678,8 +679,12 @@ class ASAPXYZ:
         if save_acronym:
             self.save_descriptor_acronym_state(filename)
 
+        # Setup extra per-structure properties
+        if extra is not None:
+            extra = {key: {'target': 'structure', 'values': value} for key, value in extra.items()}
+
         # Disable atomic environments if there isn't any data
-        write_chemiscope_input(filename + '.json.gz', self.frames, cutoff=cutoff)
+        write_chemiscope_input(filename + '.json.gz', self.frames, cutoff=cutoff, extra=extra)
 
     def write_descriptor_matrix(self, filename, desc_name_list, sbs=[], comment=''):
         """

--- a/asaplib/io/cscope.py
+++ b/asaplib/io/cscope.py
@@ -165,10 +165,6 @@ def write_chemiscope_input(filename,
         data['meta']['name'] = filename
 
     properties = {}
-    if extra is not None:
-        for name, value in extra.items():
-            properties.update(_linearize(name, value))
-
     # Read properties coming from the ase.Atoms objects
     from_frames = {}
 
@@ -225,6 +221,11 @@ def write_chemiscope_input(filename,
 
     for name, value in from_frames.items():
         properties.update(_linearize(name, value))
+
+    # Write extras - possibly overrides the internal properties
+    if extra is not None:
+        for name, value in extra.items():
+            properties.update(_linearize(name, value))
 
     data['properties'] = properties
     data['structures'] = [_frame_to_json(frame) for frame in frames]

--- a/asaplib/plot/plot_colors.py
+++ b/asaplib/plot/plot_colors.py
@@ -4,6 +4,7 @@ Color functions
 
 import os
 import numpy as np
+import pandas as pd
 
 from asaplib.data import ASAPXYZ
 
@@ -30,17 +31,27 @@ def set_color_function(fcolor='none', asapxyz=None, colorscol=0, n_samples=0,
 
     # if there is a file named "fcolor", we load it for the color scheme
     if os.path.isfile(fcolor):
-        # load the column=colorscol for color functions
-        try:
-            loadcolor = np.genfromtxt(fcolor, dtype=float)
-        except:
-            raise IOError('Error in loading fcolor files for the color scheme')
+
+        if fcolor.endswith('.csv'):
+            print("Reading as CSV - first row will be used as the header.")
+            loadcolor = pd.read_csv(fcolor)
+        else:
+            # load the column=colorscol for color functions
+            try:
+                loadcolor = pd.DataFrame(np.genfromtxt(fcolor, dtype=float))
+            except:
+                raise IOError('Error in loading fcolor files for the color scheme')
 
         # print(np.shape(loadcolor))
-        if colorscol > 0 or len(np.shape(loadcolor)) > 1:
-            plotcolor = loadcolor[:, colorscol]
+        if colorscol != '0' or len(loadcolor.columns) > 1:
+            # Convert to integer if possible (for data without header)
+            try:
+                colorscol = int(colorscol)
+            except ValueError:
+                pass
+            plotcolor = loadcolor[colorscol].values.astype(float)
         else:
-            plotcolor = loadcolor
+            plotcolor = loadcolor.values[:, 0]
         print('load file: ' + fcolor + ' for color schemes')
 
         if peratom or project_atomic:
@@ -91,13 +102,13 @@ def set_color_function(fcolor='none', asapxyz=None, colorscol=0, n_samples=0,
     if peratom and not project_atomic:
         # print(np.shape(plotcolor_atomic))
         colorscale = [np.nanmin(plotcolor_atomic), np.nanmax(plotcolor_atomic)]
-        return plotcolor, np.asarray(plotcolor_atomic), colorlabel, colorscale
+        return plotcolor, np.asarray(plotcolor_atomic), colorlabel, colorscale, loadcolor
     elif project_atomic:
         colorscale = [None, None]
-        return np.asarray(plotcolor_atomic), [], colorlabel, colorscale
+        return np.asarray(plotcolor_atomic), [], colorlabel, colorscale, loadcolor
     else:
         colorscale = [None, None]
-        return plotcolor, [], colorlabel, colorscale
+        return plotcolor, [], colorlabel, colorscale, loadcolor
 
 
 class COLOR_PALETTE:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
     ],
     install_requires=[
         'dscribe>=0.3.5', 'click>=7.0', 'numpy', 'scipy', 'scikit-learn',
-        'dscribe', 'ase', 'umap-learn', 'PyYAML', 'tqdm'
+        'dscribe', 'ase', 'umap-learn', 'PyYAML', 'tqdm', 'pandas'
     ],
     extras_require={'testing': ['pytest>=5.0']},
     python_requires='>=3.6',


### PR DESCRIPTION
Now can use CSV files for setting the colour. The --col options can be either numbers or column names (such as `enthalpy`).
Internally, pandas DataFrame is used for reading the CSV files and added to the dependencies. 
There should be no change to the existing behaviour using `dat` input format. 

In addition, this allows external data to be blended into the JSON files generated for visualisation with chemischope.