### PR TITLE
Allow additional data to be loaded for map

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -3,7 +3,7 @@
 
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/asaplib/cli/cmd_asap.py
+++ b/asaplib/cli/cmd_asap.py
@@ -467,7 +467,7 @@ def plot_pca(ctx, scale, dimension, axes,
 @map_setup_options
 @map_io_options
 @color_setup_options
-def map(ctx, fxyz, design_matrix, prefix, output,
+def map(ctx, fxyz, design_matrix, prefix, output, extra_properties,
          use_atomic_descriptors, only_use_species, peratom, keepraw,
          color, color_column, color_label, colormap, color_from_zero, normalized_by_size,
          annotate, adjusttext, style, aspect_ratio):
@@ -481,6 +481,11 @@ def map(ctx, fxyz, design_matrix, prefix, output,
         return
     if prefix is None: prefix = "ASAP-lowD-map"
     ctx.obj['asapxyz'], ctx.obj['design_matrix'], ctx.obj['design_matrix_atomic'] = read_xyz_n_dm(fxyz, design_matrix, use_atomic_descriptors, only_use_species, peratom)
+
+    # Read additional properties
+    if extra_properties:
+        ctx.obj['asapxyz'].load_properties(extra_properties)
+
     if ctx.obj['asapxyz'] is None: output = 'matrix'
     print(len(ctx.obj['design_matrix_atomic']))
     # remove the raw descriptors

--- a/asaplib/cli/cmd_cli_options.py
+++ b/asaplib/cli/cmd_cli_options.py
@@ -123,6 +123,8 @@ def map_io_options(f):
     f = click.option('--output', '-o', type=click.Choice(['xyz', 'matrix', 'none', 'chemiscope'], case_sensitive=False),
                      help='Output file format.',
                      default='xyz')(f)
+    f = click.option('--extra-properties', '-ep', type=click.Path(exists=True),
+                     help='Additional properties to be read for each frmae in CSV format.')(f)
     return f
 
 def color_setup_options(f):

--- a/asaplib/data/xyz.py
+++ b/asaplib/data/xyz.py
@@ -8,6 +8,7 @@ from ase import Atoms
 from ase.io import read, write
 from tqdm.auto import tqdm
 from joblib import Parallel, delayed
+import pandas as pd
 
 from ..io import randomString,  NpEncoder
 from ..descriptors import Atomic_Descriptors, Global_Descriptors
@@ -621,6 +622,24 @@ class ASAPXYZ:
                 else:
                     pass
                     #print("Warning: Cannot parse desc_name "+str(dn)+" when remove_descriptors.")
+
+    def load_properties(self, filename, header='infer', prefix='X', **kwargs):
+        """
+        Load properties from a CSV file
+
+        Read in the CSV file and save the columns to the `info` dictionary of the
+        frames.
+
+        Parameters
+        ----------
+        filename: (str) Name of the CSV file.
+        header: Row number of the header. Defaults to use the first row unless explicit
+          names for the columns are given
+        """
+        data = pd.read_csv(filename, header=header, prefix=prefix, **kwargs)
+
+        for frame, (_, row) in zip(self.frames, data.iterrows()):
+            frame.info.update(row.to_dict())
 
     def write(self, filename, sbs=[], save_acronym=False, wrap_output=True):
         """

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
     ],
     install_requires=[
         'dscribe>=0.3.5', 'click>=7.0', 'numpy', 'scipy', 'scikit-learn',
-        'dscribe', 'ase', 'umap-learn', 'PyYAML', 'tqdm'
+        'dscribe', 'ase', 'umap-learn', 'PyYAML', 'tqdm', 'pandas'
     ],
     extras_require={'testing': ['pytest>=5.0']},
     python_requires='>=3.6',


### PR DESCRIPTION
Additional properties (per structure) can be loaded by the `--extra-properties` option for `asap map`. This option takes a path to a CSV file. The columns of the CSV file will be added to the `info` dictionary for the loaded frames (`ase.Atoms`). The extra properties can be used for plotting by pathing the column name to the `-c` option. 

The loaded additional properties will be included in the output files as well. 